### PR TITLE
Fix Actor view stays gone on multiple actors clicked

### DIFF
--- a/ui-movie/src/main/java/com/michaldrabik/ui_movie/MovieDetailsFragment.kt
+++ b/ui-movie/src/main/java/com/michaldrabik/ui_movie/MovieDetailsFragment.kt
@@ -202,7 +202,7 @@ class MovieDetailsFragment : BaseFragment<MovieDetailsViewModel>(R.layout.fragme
 
   private fun setupActorsList() {
     actorsAdapter = ActorsAdapter().apply {
-      itemClickListener = { showFullActorView(it) }
+      itemClickListener = { if (!movieDetailsActorFullContainer.isVisible) showFullActorView(it) }
     }
     movieDetailsActorsRecycler.apply {
       setHasFixedSize(true)

--- a/ui-show/src/main/java/com/michaldrabik/ui_show/ShowDetailsFragment.kt
+++ b/ui-show/src/main/java/com/michaldrabik/ui_show/ShowDetailsFragment.kt
@@ -237,7 +237,7 @@ class ShowDetailsFragment : BaseFragment<ShowDetailsViewModel>(R.layout.fragment
 
   private fun setupActorsList() {
     actorsAdapter = ActorsAdapter().apply {
-      itemClickListener = { showFullActorView(it) }
+      itemClickListener = { if (!showDetailsActorFullContainer.isVisible) showFullActorView(it) }
     }
     showDetailsActorsRecycler.apply {
       setHasFixedSize(true)


### PR DESCRIPTION
When clicking on multiple actorviews in show/movie, first one stays hidden in actorsadapter cause `hideFullActorView()` never gets called. Quick fix by checking if `movieDetailsActorFullContainer` is not visible before opening other actorview