### PR TITLE
Make watchlisted shows visable in series statistics

### DIFF
--- a/ui-statistics/src/main/java/com/michaldrabik/ui_statistics/StatisticsViewModel.kt
+++ b/ui-statistics/src/main/java/com/michaldrabik/ui_statistics/StatisticsViewModel.kt
@@ -54,9 +54,10 @@ class StatisticsViewModel @Inject constructor(
       val language = translationsRepository.getLanguage()
 
       val myShows = showsRepository.myShows.loadAll()
+      val watchlistShows = showsRepository.watchlistShows.loadAll() // Add shows from watchlist
       val hiddenShows = showsRepository.hiddenShows.loadAll()
 
-      val shows = (myShows + hiddenShows).distinctBy { it.traktId }
+      val shows = (myShows + watchlistShows + hiddenShows).distinctBy { it.traktId }
       val showsIds = shows.map { it.traktId }
 
       val episodes = batchEpisodes(showsIds)

--- a/ui-statistics/src/main/res/values/strings.xml
+++ b/ui-statistics/src/main/res/values/strings.xml
@@ -2,7 +2,7 @@
 <resources>
 
   <string name="textStatistics">Statistics</string>
-  <string name="textStatisticsEmpty">At least one show must be present in <b>My Shows</b>\nor <b>Watchlist</b> before statistics can be displayed.</string>
+  <string name="textStatisticsEmpty">At least one show must be present in <b>My Shows</b>\nbefore statistics can be displayed.</string>
   <string name="textStatisticsMostWatchedShows">Most Viewed Shows</string>
   <string name="textStatisticsTotalTimeSpent">Total Time Spent Watching</string>
   <string name="textStatisticsTotalTimeItIs">and it is</string>

--- a/ui-statistics/src/main/res/values/strings.xml
+++ b/ui-statistics/src/main/res/values/strings.xml
@@ -2,7 +2,7 @@
 <resources>
 
   <string name="textStatistics">Statistics</string>
-  <string name="textStatisticsEmpty">At least one show must be present in <b>My Shows</b>\nbefore statistics can be displayed.</string>
+  <string name="textStatisticsEmpty">At least one show must be present in <b>My Shows</b>\nor <b>Watchlist</b> before statistics can be displayed.</string>
   <string name="textStatisticsMostWatchedShows">Most Viewed Shows</string>
   <string name="textStatisticsTotalTimeSpent">Total Time Spent Watching</string>
   <string name="textStatisticsTotalTimeItIs">and it is</string>


### PR DESCRIPTION
This pull request resolved #665 that I opened a while back in January.

If you have watched an episode of a series but haven't marked it as watched, opting to add it to your watchlist instead, it will still be included in the statistics tab rather than being excluded.

I would be more then happy to make adjustments if necessary. Thank you for your time.