### PR TITLE
Remove gcloudApiKey leftovers

### DIFF
--- a/data-remote/build.gradle
+++ b/data-remote/build.gradle
@@ -33,7 +33,6 @@ android {
     buildConfigField("String", "TRAKT_CLIENT_ID", properties.getProperty("traktClientId"))
     buildConfigField("String", "TRAKT_CLIENT_SECRET", properties.getProperty("traktClientSecret"))
     buildConfigField("String", "TMDB_API_KEY", properties.getProperty("tmdbApiKey"))
-    buildConfigField("String", "CLOUD_API_KEY", properties.getProperty("gcloudApiKey"))
     buildConfigField("String", "OMDB_API_KEY", properties.getProperty("omdbApiKey"))
     buildConfigField 'String', 'VER_NAME', "\"${versions.versionName}\""
   }


### PR DESCRIPTION
## Overview
This Pull Request remove`gcloudApiKey` leftovers. This step is crucial to prevent build failures.

## Changes
- Remove `gcloudApiKey` of build.gradle in the `data.rempte`module.

## Acknowledgements
A huge thank you to everyone involved in the development of Showly 2.0!

