### PR TITLE
Add poster translations

### DIFF
--- a/data-remote/src/main/java/com/michaldrabik/data_remote/tmdb/model/TmdbImage.kt
+++ b/data-remote/src/main/java/com/michaldrabik/data_remote/tmdb/model/TmdbImage.kt
@@ -1,5 +1,7 @@
 package com.michaldrabik.data_remote.tmdb.model
 
+import kotlin.math.sqrt
+
 data class TmdbImage(
   val file_path: String,
   val vote_average: Float,
@@ -10,4 +12,15 @@ data class TmdbImage(
   fun isPlain() = iso_639_1 == null
 
   fun isEnglish() = iso_639_1 == "en"
+
+  fun isLanguage(language: String) = iso_639_1 == language
+
+  fun getVoteScore(): Double {
+    // Calculate the Wilson score interval lower bound: https://en.wikipedia.org/wiki/Binomial_proportion_confidence_interval#Wilson_score_interval
+    val z = 1.96 // Z-score corresponding to a 95% confidence level
+    val phat = vote_average / 10.0 // Proportion of average rating out of 10
+    val numerator = phat + (z * z) / (2 * vote_count) - z * sqrt((phat * (1 - phat) + (z * z) / (4 * vote_count)) / vote_count)
+    val denominator = 1 + (z * z) / vote_count
+    return if (vote_count > 0) (numerator / denominator) else 0.0
+  }
 }

--- a/repository/src/main/java/com/michaldrabik/repository/images/ShowImagesProvider.kt
+++ b/repository/src/main/java/com/michaldrabik/repository/images/ShowImagesProvider.kt
@@ -6,6 +6,7 @@ import com.michaldrabik.data_remote.RemoteDataSource
 import com.michaldrabik.data_remote.aws.model.AwsImages
 import com.michaldrabik.data_remote.tmdb.model.TmdbImage
 import com.michaldrabik.data_remote.tmdb.model.TmdbImages
+import com.michaldrabik.repository.TranslationsRepository
 import com.michaldrabik.repository.mappers.Mappers
 import com.michaldrabik.ui_model.IdTmdb
 import com.michaldrabik.ui_model.IdTrakt
@@ -32,6 +33,7 @@ class ShowImagesProvider @Inject constructor(
   private val remoteSource: RemoteDataSource,
   private val localSource: LocalDataSource,
   private val mappers: Mappers,
+  private var translationsRepository: TranslationsRepository
 ) {
 
   private val unavailableCache = mutableSetOf<IdTrakt>()
@@ -170,13 +172,18 @@ class ShowImagesProvider @Inject constructor(
     }
   }
 
-  private fun findBestImage(images: List<TmdbImage>, type: ImageType) =
-    images
-      .filter { if (type == POSTER) it.isEnglish() else it.isPlain() }
-      .sortedWith(compareBy({ it.vote_count }, { it.vote_average }))
-      .lastOrNull()
-      ?: images.firstOrNull { if (type == POSTER) it.isEnglish() else it.isPlain() }
-      ?: images.firstOrNull()
+  private fun findBestImage(images: List<TmdbImage>, type: ImageType): TmdbImage? {
+    val language = translationsRepository.getLanguage()
+    val comparator = when (type) {
+      POSTER -> compareBy<TmdbImage> { it.isLanguage(language) }
+        .thenBy { it.isEnglish() }
+        .thenBy { it.isPlain() }
+      else -> compareBy<TmdbImage> { it.isPlain() }
+        .thenBy { it.isLanguage(language) }
+        .thenBy { it.isEnglish() }
+    }
+    return images.maxWithOrNull(comparator.thenBy { it.getVoteScore() })
+  }
 
   suspend fun deleteLocalCache() = withContext(dispatchers.IO) {
     localSource.showImages.deleteAll()

--- a/repository/src/main/java/com/michaldrabik/repository/settings/SettingsRepository.kt
+++ b/repository/src/main/java/com/michaldrabik/repository/settings/SettingsRepository.kt
@@ -133,6 +133,8 @@ class SettingsRepository @Inject constructor(
         movieTranslations.deleteByLanguage(input)
         episodesTranslations.deleteByLanguage(input)
         people.deleteTranslations()
+        movieImages.deleteAll()
+        showImages.deleteAll()
       }
     }
   }


### PR DESCRIPTION
## Overview
This Pull Request introduces a version for Showly 2.0 that allows poster translations to be displayed based on the user's configured language.

It resolved Issues as #797 when a translation is available

## Changes
- Changed fetchEpisodeImage method to unify it with the rest of fetch"Media"Image
- Changed the loadRemoteImage of the EpisodeImagesProvider to unify it with the style of the rest of the ImagesProviders.
- Added getVoteScore method in TmdbImage to get a score based on count votes and average votes using wilson's score.
- Changed the findBestImage method to choose the first image in the language selected by the user, or failing that, in English, or failing that, in ‘null’, or failing that, in whatever language there is, all of them sorted by their VoteScore.
- Added clearing of image cache when switching languages

## Acknowledgements
A huge thank you to everyone involved in developing Showly 2.0.

